### PR TITLE
Add heartbeat request

### DIFF
--- a/src/cqerl_client.erl
+++ b/src/cqerl_client.erl
@@ -25,6 +25,11 @@ end).
 
 -define(IS_IOLIST(L), is_list(L) orelse is_binary(L)).
 
+-define(HEARTBEAT_MAX_INITIAL_CHECK_INTERVAL_MSECS, 90000). % (Max initial heartbeat interval / 2) - 1,5 min
+-define(HEARTBEAT_CHECK_INTERVAL_MSECS, 180000). % Run heartbeat message every 3 minutes
+-define(HEARTBEAT_MAX_IDLE_TIME_SECS, 180). % Check whether there was any activity on a socket in last 3 minutes
+
+
 -export([init/1, terminate/3,
          starting/2,    starting/3,
          live/2,        live/3,
@@ -56,7 +61,8 @@ end).
     available_slots = [] :: list(integer()),
     waiting_preparation = [],
     mode :: hash | pooler,
-    key :: {term(), term()}
+    key :: {term(), term()},
+    last_socket_send_secs :: integer()
 }).
 
 -record(client_user, {
@@ -154,7 +160,7 @@ init([Inet, Opts, OptGetter, Key]) ->
             {AuthHandler, AuthArgs} = OptGetter(auth),
             cqerl:put_protocol_version(OptGetter(protocol_version)),
             {ok, OptionsFrame} = cqerl_protocol:options_frame(#cqerl_frame{}),
-            State = #client_state{
+            State0 = #client_state{
                 socket=Socket, trans=Transport, inet=Inet,
                 authmod=AuthHandler, authargs=AuthArgs,
                 users=[],
@@ -163,8 +169,10 @@ init([Inet, Opts, OptGetter, Key]) ->
                 key=Key,
                 mode=cqerl_app:mode()
             },
-            send_to_db(State, OptionsFrame),
+            State = send_to_db(State0, OptionsFrame),
             activate_socket(State),
+            HeartbeatInterval = ?HEARTBEAT_MAX_INITIAL_CHECK_INTERVAL_MSECS + random:uniform(?HEARTBEAT_MAX_INITIAL_CHECK_INTERVAL_MSECS),
+            erlang:send_after(HeartbeatInterval, self(), heartbeat_check),
             {ok, starting, State};
 
         {error, Reason} ->
@@ -346,8 +354,8 @@ handle_info({ Transport, Socket, BinaryMsg }, starting, State = #client_state{ s
             SelectedVersion = choose_cql_version(proplists:lookup('CQL_VERSION', Payload)),
             {ok, StartupFrame} = cqerl_protocol:startup_frame(#cqerl_frame{}, #cqerl_startup_options{compression=Compression,
                                                                                                      cql_version=SelectedVersion}),
-            send_to_db(State, StartupFrame),
-            {next_state, starting, State#client_state{compression_type=Compression}};
+            State1 = send_to_db(State, StartupFrame),
+            {next_state, starting, State1#client_state{compression_type=Compression}};
 
         %% Server tells us all is clear, we can start to throw queries at it
         {ok, #cqerl_frame{opcode=?CQERL_OP_READY}, _, Delayed} ->
@@ -363,8 +371,8 @@ handle_info({ Transport, Socket, BinaryMsg }, starting, State = #client_state{ s
 
                 {reply, Reply, AuthState} ->
                     {ok, AuthFrame} = cqerl_protocol:auth_frame(base_frame(State), Reply),
-                    send_to_db(State, AuthFrame),
-                    {next_state, starting, State#client_state{ authstate=AuthState }}
+                    State1 = send_to_db(State, AuthFrame),
+                    {next_state, starting, State1#client_state{ authstate=AuthState }}
             end;
 
         %% Server tells us we need to give another piece of data
@@ -375,8 +383,8 @@ handle_info({ Transport, Socket, BinaryMsg }, starting, State = #client_state{ s
                     stop_during_startup({auth_client_closed, Reason}, State);
                 {reply, Reply, AuthState} ->
                     {ok, AuthFrame} = cqerl_protocol:auth_frame(base_frame(State), Reply),
-                    send_to_db(State, AuthFrame),
-                    {next_state, starting, State#client_state{ authstate=AuthState }}
+                    State1 = send_to_db(State, AuthFrame),
+                    {next_state, starting, State1#client_state{ authstate=AuthState }}
             end;
 
         %% Server tells us something screwed up while authenticating
@@ -404,8 +412,8 @@ handle_info({ Transport, Socket, BinaryMsg }, starting, State = #client_state{ s
         {ok, #cqerl_frame{opcode=?CQERL_OP_RESULT}, {set_keyspace, _KeySpaceName}, Delayed} ->
             {next_state, live, switch_to_live_state(State) }
     end,
-    {_, _, State1} = Resp,
-    activate_socket(State1),
+    {_, _, State2} = Resp,
+    activate_socket(State2),
     append_delayed_segment(Resp, Delayed);
 
 handle_info({ rows, Call, Result }, live, State) ->
@@ -487,7 +495,11 @@ handle_info({ Transport, Socket, BinaryMsg }, live, State = #client_state{ socke
             {next_state, live, release_stream_id(StreamID, State)};
 
         {ok, #cqerl_frame{opcode=?CQERL_OP_EVENT}, _EventTerm, Delayed} ->
-            ok%% TODO Manage incoming server-driven events
+            ok; %% TODO Manage incoming server-driven events
+        {ok, #cqerl_frame{opcode=?CQERL_OP_SUPPORTED}, _Payload, Delayed} ->
+            %% SUPPORTED is the message received from Cassandra for OPTIONS request,
+            %% which we use for heartbeats. We need to handle that for live state without any State modifications.
+            {next_state, live, State}
     end,
 
     case Resp of
@@ -534,8 +546,21 @@ handle_info({'DOWN', _MonitorRef, process, Pid, _Info}, live, State=#client_stat
             end
     end;
 
+handle_info(heartbeat_check, StateName, State = #client_state{last_socket_send_secs = LastSocketSendSecs}) ->
+    State1 = case heartbeat_idle_time_exceeded(LastSocketSendSecs) of
+        true ->
+            %% OPTIONS frame is what Java driver sends as a heartbeat in case of idle connection
+            {ok, OptionsFrame} = cqerl_protocol:options_frame(#cqerl_frame{}),
+            send_to_db(State, OptionsFrame);
+        false ->
+            State
+    end,
+
+    erlang:send_after(?HEARTBEAT_CHECK_INTERVAL_MSECS, self(), heartbeat_check),
+    {next_state, StateName, State1};
+
 handle_info(Info, StateName, State) ->
-    io:format("Received message ~w while in state ~w~n", [StateName, Info]),
+    io:format("Received message ~w while in state ~w~n", [Info, StateName]),
     {next_state, StateName, State}.
 
 
@@ -631,18 +656,18 @@ release_stream_id(StreamID, State=#client_state{available_slots=Slots, queries=Q
 process_outgoing_query(prepare, Query, State=#client_state{queries=Queries0}) ->
     {BaseFrame, State1} = seq_frame(State),
     {ok, PrepareFrame} = cqerl_protocol:prepare_frame(BaseFrame, Query),
-    send_to_db(State1, PrepareFrame),
-    maybe_signal_busy(State1),
+    State2 = send_to_db(State1, PrepareFrame),
+    maybe_signal_busy(State2),
     Queries1 = orddict:store(BaseFrame#cqerl_frame.stream_id, {preparing, Query}, Queries0),
-    State1#client_state{queries=Queries1};
+    State2#client_state{queries=Queries1};
 
 process_outgoing_query(Call=#cql_call{}, Batch=#cql_query_batch{}, State=#client_state{queries=Queries0}) ->
     {BaseFrame, State1} = seq_frame(State),
     {ok, BatchFrame} = cqerl_protocol:batch_frame(BaseFrame, Batch),
-    send_to_db(State1, BatchFrame),
-    maybe_signal_busy(State1),
+    State2 = send_to_db(State1, BatchFrame),
+    maybe_signal_busy(State2),
     Queries1 = orddict:store(BaseFrame#cqerl_frame.stream_id, {Call, Batch}, Queries0),
-    State1#client_state{queries=Queries1};
+    State2#client_state{queries=Queries1};
 
 process_outgoing_query(Call,
                        {queued, Continuation=#cql_result{cql_query=#cql_query{statement=Statement}}},
@@ -743,8 +768,8 @@ maybe_set_keyspace(State=#client_state{keyspace=Keyspace}) ->
         #cqerl_query_parameters{},
         #cqerl_query{statement = <<"USE ", KeyspaceName/binary>>}
     ),
-    send_to_db(State, Frame),
-    {starting, State}.
+    State1 = send_to_db(State, Frame),
+    {starting, State1}.
 
 switch_to_live_state(State=#client_state{users=Users, keyspace=Keyspace,
                                          inet=Inet, key=Key, mode=Mode}) ->
@@ -772,9 +797,15 @@ switch_to_live_state(State=#client_state{users=Users, keyspace=Keyspace,
 
 
 
-send_to_db(#client_state{trans=tcp, socket=Socket}, Data) when is_binary(Data) ->
+send_to_db(ClientState, Data) when is_binary(Data) ->
+    do_send_to_db(ClientState, Data),
+    {Mega, Secs, _} = os:timestamp(),
+    LastSocketSendSecs = Mega * 1000000 + Secs,
+    ClientState#client_state{last_socket_send_secs = LastSocketSendSecs}.
+
+do_send_to_db(#client_state{trans=tcp, socket=Socket}, Data) when is_binary(Data) ->
     gen_tcp:send(Socket, Data);
-send_to_db(#client_state{trans=ssl, socket=Socket}, Data) when is_binary(Data) ->
+do_send_to_db(#client_state{trans=ssl, socket=Socket}, Data) when is_binary(Data) ->
     ssl:send(Socket, Data).
 
 
@@ -916,3 +947,9 @@ stop_during_startup(Reason, State = #client_state{users = Users}) ->
     % connect.
     cqerl_app:mode() =:= pooler andalso timer:sleep(200),
     {stop, normal, State#client_state{socket=undefined}}.
+
+
+heartbeat_idle_time_exceeded(LastSocketSendSecs) ->
+    {Mega, Secs, _} = os:timestamp(),
+    CurrentSecs = Mega * 1000000 + Secs,
+    LastSocketSendSecs < (CurrentSecs - ?HEARTBEAT_MAX_IDLE_TIME_SECS).


### PR DESCRIPTION
The very basic implementation of heartbeart request, but this should be good enough for us:
* uses Cassandra OPTIONS request for a heartbeat - https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v3.spec#L278
* just check every X seconds whether any data was transferred to a socket in Y seconds

We can easily make that configurable whenever we want (just don't run `erlang:send_after(HeartbeatInterval, self(), heartbeat_check),` in client's init then).

CT still pass, tested in dev env.

@loucash @spirytus please review