### PR TITLE
(feat) [P6-2227] Upgrade pooler to 1.5.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,6 +5,6 @@
   {lz4, ".*", {git, "https://github.com/szktty/erlang-lz4.git", {tag, "0.2.2"}}},
   {semver, ".*", {git, "https://github.com/nebularis/semver.git", "c7d509"}},
   {uuid, ".*", {git, "https://github.com/okeuday/uuid.git", {tag, "v1.4.1"}}},
-  {pooler, ".*", {git, "https://github.com/seth/pooler.git", {tag, "1.5.0"}}},
+  {pooler, ".*", {git, "https://github.com/seth/pooler.git", {tag, "1.5.2"}}},
   {re2, ".*", {git, "https://github.com/tuncer/re2.git", {tag, "v1.7.1"}}}
 ]}.


### PR DESCRIPTION
OTP 20.1 doesn't like 'export_all'